### PR TITLE
add notebook with EMA code snippets for Python

### DIFF
--- a/EMA_snippets/EMA_code_snippets_for_Python.ipynb
+++ b/EMA_snippets/EMA_code_snippets_for_Python.ipynb
@@ -1,0 +1,1217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e623d8e6",
+   "metadata": {},
+   "source": [
+    "# Explanatory Model Analysis - code snippets for Python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "448b4969",
+   "metadata": {},
+   "source": [
+    "## 4.3 Models for RMS Titanic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a361035e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dalex as dx\n",
+    "titanic = dx.datasets.load_titanic()\n",
+    "X = titanic.drop(columns='survived')\n",
+    "y = titanic.survived"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a96455c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n",
+    "from sklearn.compose import make_column_transformer\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "\n",
+    "preprocess = make_column_transformer(\n",
+    "    (StandardScaler(), ['age', 'fare', 'parch', 'sibsp']),\n",
+    "    (OneHotEncoder(), ['gender', 'class', 'embarked']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bd79035",
+   "metadata": {},
+   "source": [
+    "### 4.3.1  Logistic regression model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7783522b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "titanic_lr = make_pipeline(\n",
+    "    preprocess,\n",
+    "    LogisticRegression(penalty = 'l2'))\n",
+    "titanic_lr.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e54d507",
+   "metadata": {},
+   "source": [
+    "### 4.3.2 Random forest model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6503088",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "\n",
+    "titanic_rf = make_pipeline(\n",
+    "    preprocess,\n",
+    "    RandomForestClassifier(max_depth = 3, n_estimators = 500))\n",
+    "titanic_rf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "166ac9b0",
+   "metadata": {},
+   "source": [
+    "### 4.3.3 Gradient boosting model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "334e10ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import GradientBoostingClassifier\n",
+    "\n",
+    "titanic_gbc = make_pipeline(\n",
+    "    preprocess,\n",
+    "    GradientBoostingClassifier(n_estimators = 100))\n",
+    "titanic_gbc.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9836bd75",
+   "metadata": {},
+   "source": [
+    "### 4.3.4 Support vector machine model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8337b0e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.svm import SVC\n",
+    "\n",
+    "titanic_svm = make_pipeline(\n",
+    "    preprocess,\n",
+    "    SVC(probability = True))\n",
+    "titanic_svm.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95964dc3",
+   "metadata": {},
+   "source": [
+    "### 4.3.5 Models’ predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28dd4f04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "johnny_d = pd.DataFrame({'gender': ['male'],\n",
+    "                       'age'     : [8],\n",
+    "                       'class'   : ['1st'],\n",
+    "                       'embarked': ['Southampton'],\n",
+    "                       'fare'    : [72],\n",
+    "                       'sibsp'   : [0],\n",
+    "                       'parch'   : [0]},\n",
+    "                      index = ['JohnnyD'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "980807ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'''The predicted probability of survival for Johnny D\n",
+    "logistic regression model: {titanic_lr.predict_proba(johnny_d)}\n",
+    "random forest model: {titanic_rf.predict_proba(johnny_d)}\n",
+    "gradient boosting model: {titanic_gbc.predict_proba(johnny_d)}\n",
+    "support vector machine model: {titanic_svm.predict_proba(johnny_d)}''')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04f33f09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "henry = pd.DataFrame({'gender'   : ['male'],\n",
+    "                       'age'     : [47],\n",
+    "                       'class'   : ['1st'],\n",
+    "                       'embarked': ['Cherbourg'],\n",
+    "                       'fare'    : [25],\n",
+    "                       'sibsp'   : [0],\n",
+    "                       'parch'   : [0]},\n",
+    "                      index = ['Henry'])\n",
+    "\n",
+    "\n",
+    "print(f'''The predicted probability of survival for Henry\n",
+    "logistic regression model: {titanic_lr.predict_proba(henry)}\n",
+    "random forest model: {titanic_rf.predict_proba(henry)}\n",
+    "gradient boosting model: {titanic_gbc.predict_proba(henry)}\n",
+    "support vector machine model: {titanic_svm.predict_proba(henry)}''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f105b7c",
+   "metadata": {},
+   "source": [
+    "### 4.3.6 Models’ explainers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce464e98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "titanic_rf_exp = dx.Explainer(titanic_rf, \n",
+    "                    X, y, label = \"Titanic RF Pipeline\")\n",
+    "titanic_lr_exp = dx.Explainer(titanic_lr, \n",
+    "                    X, y, label = \"Titanic LR Pipeline\")\n",
+    "titanic_gbc_exp = dx.Explainer(titanic_gbc, \n",
+    "                    X, y, label = \"Titanic GBC Pipeline\")\n",
+    "titanic_svm_exp = dx.Explainer(titanic_svm, \n",
+    "                    X, y, label = \"Titanic SVM Pipeline\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c028974d",
+   "metadata": {},
+   "source": [
+    "## 4.6 Models for apartment prices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bb1d0bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dalex as dx\n",
+    "apartments = dx.datasets.load_apartments()\n",
+    "X = apartments.drop(columns='m2_price')\n",
+    "y = apartments['m2_price']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecbebabb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import StandardScaler, OneHotEncoder\n",
+    "from sklearn.compose import make_column_transformer\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "\n",
+    "preprocess = make_column_transformer(\n",
+    "    (StandardScaler(), ['construction_year', 'surface', 'floor', 'no_rooms']),\n",
+    "    (OneHotEncoder(), ['district']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36ea1d89",
+   "metadata": {},
+   "source": [
+    "### 4.6.1  Linear regression model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6acd5180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LinearRegression\n",
+    "\n",
+    "apartments_lm = make_pipeline(\n",
+    "    preprocess,\n",
+    "    LinearRegression())\n",
+    "apartments_lm.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3f24f11",
+   "metadata": {},
+   "source": [
+    "### 4.6.2 Random forest model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf2f1f70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "\n",
+    "apartments_rf = make_pipeline(\n",
+    "    preprocess,\n",
+    "    RandomForestRegressor(max_depth = 3, n_estimators = 500))\n",
+    "apartments_rf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd22a604",
+   "metadata": {},
+   "source": [
+    "### 4.6.3 Support vector machine model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "601dbaf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.svm import SVR\n",
+    "\n",
+    "apartments_svm = make_pipeline(\n",
+    "    preprocess,\n",
+    "    SVR())\n",
+    "apartments_svm.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b97cf01b",
+   "metadata": {},
+   "source": [
+    "### Models' predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1511c83a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apartments_test = dx.datasets.load_apartments_test()\n",
+    "apartments_test = apartments_test.drop(columns='m2_price')\n",
+    "\n",
+    "apartments_lm.predict(apartments_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a630c8ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apartments_rf.predict(apartments_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d214c999",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apartments_svm.predict(apartments_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "797345f9",
+   "metadata": {},
+   "source": [
+    "### 4.6.5 Models’ explainers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "541ba767",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apartments_lm_exp = dx.Explainer(apartments_lm, X, y, \n",
+    "                      label = \"Apartments LM Pipeline\")\n",
+    "apartments_rf_exp = dx.Explainer(apartments_rf, X, y, \n",
+    "                      label = \"Apartments RF Pipeline\")\n",
+    "apartments_svm_exp = dx.Explainer(apartments_svm, X, y, \n",
+    "                      label = \"Apartments SVM Pipeline\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "728b6269",
+   "metadata": {},
+   "source": [
+    "## 6.7 Break-down Plots for Additive Attributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdb32736",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "henry = pd.DataFrame({'gender'   : ['male'],\n",
+    "                       'age'     : [47],\n",
+    "                       'class'   : ['1st'],\n",
+    "                       'embarked': ['Cherbourg'],\n",
+    "                       'fare'    : [25],\n",
+    "                       'sibsp'   : [0],\n",
+    "                       'parch'   : [0]},\n",
+    "                      index = ['Henry'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96eca76c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry = titanic_rf_exp.predict_parts(henry, \n",
+    "             type = 'break_down')\n",
+    "bd_henry.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abde37f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c8b9aaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "bd_henry = titanic_rf_exp.predict_parts(henry,\n",
+    "        type = 'break_down',\n",
+    "        order = np.array(['gender', 'class', 'age',\n",
+    "            'embarked', 'fare', 'sibsp', 'parch']))\n",
+    "bd_henry.plot(max_vars = 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1d85825",
+   "metadata": {},
+   "source": [
+    "## 7.6 Break-down Plots for Interactions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4898b66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "henry = pd.DataFrame({'gender': ['male'], 'age': [47],\n",
+    "           'class': ['1st'],\n",
+    "           'embarked': ['Cherbourg'], 'fare': [25],\n",
+    "           'sibsp': [0], 'parch': [0]},\n",
+    "           index = ['Henry'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f35d8ff3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry = titanic_rf_exp.predict_parts(henry, \n",
+    "                type = 'break_down_interactions', \n",
+    "                interaction_preference = 10)\n",
+    "bd_henry.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "929b00d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "392b00b5",
+   "metadata": {},
+   "source": [
+    "## 8.6 Shapley Additive Explanations (SHAP) for Average Attributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54b244f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "henry = pd.DataFrame({'gender'   : ['male'],\n",
+    "                       'age'     : [47],\n",
+    "                       'class'   : ['1st'],\n",
+    "                       'embarked': ['Cherbourg'],\n",
+    "                       'fare'    : [25],\n",
+    "                       'sibsp'   : [0],\n",
+    "                       'parch'   : [0]},\n",
+    "                      index = ['Henry'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3dd2dcf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry = titanic_rf_exp.predict_parts(henry, type = 'shap')\n",
+    "bd_henry.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dd330ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bd_henry.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c0c5a45",
+   "metadata": {},
+   "source": [
+    "## 9.7 Local Interpretable Model-agnostic Explanations (LIME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a1f3ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "titanic = dx.datasets.load_titanic()\n",
+    "X = titanic.drop(columns='survived')\n",
+    "y = titanic.survived\n",
+    "\n",
+    "from sklearn import preprocessing\n",
+    "le = preprocessing.LabelEncoder()\n",
+    "\n",
+    "X['gender']   = le.fit_transform(X['gender'])\n",
+    "X['class']    = le.fit_transform(X['class'])\n",
+    "X['embarked'] = le.fit_transform(X['embarked'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "991af86e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier as rfc\n",
+    "titanic_fr = rfc()\n",
+    "titanic_fr.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2a83140",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "henry = pd.Series([1, 47.0, 0, 1, 25.0, 0, 0], \n",
+    "                  index =['gender', 'age', 'class', 'embarked',\n",
+    "                          'fare', 'sibsp', 'parch'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1aaaed26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lime.lime_tabular import LimeTabularExplainer \n",
+    "explainer = LimeTabularExplainer(X, \n",
+    "                      feature_names=X.columns, \n",
+    "                      class_names=['died', 'survived'], \n",
+    "                      discretize_continuous=False, \n",
+    "                      verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f61f26b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lime = explainer.explain_instance(henry, titanic_fr.predict_proba)\n",
+    "lime.show_in_notebook(show_table=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87080f3a",
+   "metadata": {},
+   "source": [
+    "## 10.7 Ceteris-paribus Profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d1e1f2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "henry = pd.DataFrame({'gender'   : ['male'],\n",
+    "                       'age'     : [47],\n",
+    "                       'class'   : ['1st'],\n",
+    "                       'embarked': ['Cherbourg'],\n",
+    "                       'fare'    : [25],\n",
+    "                       'sibsp'   : [0],\n",
+    "                       'parch'   : [0]},\n",
+    "                      index = ['Henry'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e019140e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp_henry = titanic_rf_exp.predict_profile(henry)\n",
+    "cp_henry.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65cbf312",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp_henry.plot(variables = ['age', 'fare'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7a42033",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp_henry.plot(variables = ['class', 'embarked'],\n",
+    "               variable_type = 'categorical')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4621c2d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp_henry2 = titanic_lr_exp.predict_profile(henry)\n",
+    "cp_henry.plot(cp_henry2, variables = ['age', 'fare'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa04e2f2",
+   "metadata": {},
+   "source": [
+    "## 15.7 Model-performance Measures "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34f62bb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_rf = titanic_rf_exp.model_performance(model_type = \"classification\", \n",
+    "          cutoff = 0.5)\n",
+    "mp_rf.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3fac29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# back to original X \n",
+    "X = titanic.drop(columns='survived')\n",
+    "y = titanic.survived"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23ec8791",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "from sklearn.metrics import roc_curve, auc\n",
+    "y_score = titanic_rf_exp.predict(X)\n",
+    "fpr, tpr, thresholds = roc_curve(y, y_score)\n",
+    "fig = px.area(x=fpr, y=tpr,\n",
+    "    title=f'ROC Curve (AUC={auc(fpr, tpr):.4f})',\n",
+    "    labels=dict(x='False Positive Rate', y='True Positive Rate'),\n",
+    "    width=700, height=500)\n",
+    "fig.add_shape(\n",
+    "    type='line', line=dict(dash='dash'),\n",
+    "    x0=0, x1=1, y0=0, y1=1)\n",
+    "fig.update_yaxes(scaleanchor=\"x\", scaleratio=1)\n",
+    "fig.update_xaxes(constrain='domain')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ff5d511",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame({'False Positive Rate': fpr,\n",
+    "        'True Positive Rate': tpr }, index=thresholds)\n",
+    "df.index.name = \"Thresholds\"\n",
+    "df.columns.name = \"Rate\"\n",
+    "fig_thresh = px.line(df, \n",
+    "    title='TPR and FPR at every threshold', width=700, height=500)\n",
+    "fig_thresh.update_yaxes(scaleanchor=\"x\", scaleratio=1)\n",
+    "fig_thresh.update_xaxes(range=[0, 1], constrain='domain')\n",
+    "fig_thresh.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bf8a9fc",
+   "metadata": {},
+   "source": [
+    "## 16.7 Variable-importance Measures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70164529",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_rf = titanic_rf_exp.model_parts()\n",
+    "mp_rf.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1d04eea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_rf.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3d3fae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vi_grouped = titanic_rf_exp.model_parts(\n",
+    "                variable_groups={'personal': ['gender', 'age', \n",
+    "                                              'sibsp', 'parch'],\n",
+    "                                   'wealth': ['class', 'fare']})\n",
+    "vi_grouped.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4bf6378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vi_grouped.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bfbcb80",
+   "metadata": {},
+   "source": [
+    "## 17.7 Partial-dependence Profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52572d4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd_rf = titanic_rf_exp.model_profile(variables = ['age', 'fare'])\n",
+    "pd_rf.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d9800b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd_rf.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35654b47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd_rf.plot(geom = 'profiles')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f60f3fe4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_rf = titanic_rf_exp.model_profile( variable_type = 'categorical')\n",
+    "mp_rf.plot(variables = ['gender', 'class'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b75d994d",
+   "metadata": {},
+   "source": [
+    "### 17.7.1 Grouped partial-dependence profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22066a41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_rf = titanic_rf_exp.model_profile(groups = 'class', \n",
+    "                                  variables = ['age', 'fare'])\n",
+    "mp_rf.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a1a397",
+   "metadata": {},
+   "source": [
+    "### 17.7.2 Contrastive partial-dependence profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29969cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdp_rf = titanic_rf_exp.model_profile()\n",
+    "pdp_lr = titanic_lr_exp.model_profile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32f2a880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdp_rf.plot(pdp_lr, variables = ['age', 'fare'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6ee93a1",
+   "metadata": {},
+   "source": [
+    "## 18.7 Local-dependence and Accumulated-local Profiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c38f69d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ld_rf = titanic_rf_exp.model_profile(type = 'conditional')\n",
+    "ld_rf.result['_label_'] = 'LD profiles'\n",
+    "ld_rf.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0170436d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ld_rf.plot(variables = ['age', 'fare'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19f7ac24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "al_rf = titanic_rf_exp.model_profile(type = 'accumulated')\n",
+    "al_rf.result['_label_'] = 'AL profiles'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2db70c2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "al_rf.plot(ld_rf, variables = ['age', 'fare'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2542bc1a",
+   "metadata": {},
+   "source": [
+    "## 19.7 Residual-diagnostics Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57bcfcfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md_rf = apartments_rf_exp.model_diagnostics()\n",
+    "md_rf.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cea57c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md_rf.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "109585a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md_rf.plot(variable = \"ids\", yvariable = \"abs_residuals\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b7bc4b2",
+   "metadata": {},
+   "source": [
+    "## 21 FIFA 19 "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "392859bf",
+   "metadata": {},
+   "source": [
+    "### 21.2.2 Data preparation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7c88f81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dalex as dx\n",
+    "fifa = dx.datasets.load_fifa()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f013886",
+   "metadata": {},
+   "source": [
+    "### 21.4.2 Model assembly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "420734ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightgbm import LGBMRegressor\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import numpy as np\n",
+    "\n",
+    "X = fifa.drop([\"nationality\", \"overall\", \"potential\", \n",
+    "     \"value_eur\", \"wage_eur\"], axis = 1)\n",
+    "y = fifa['value_eur']\n",
+    "ylog = np.log(y)\n",
+    "\n",
+    "X_train, X_test, ylog_train, ylog_test, y_train, y_test = \\\n",
+    "     train_test_split(X, ylog, y, test_size = 0.25, random_state = 4)\n",
+    "gbm_model = LGBMRegressor()\n",
+    "gbm_model.fit(X_train, ylog_train, verbose = False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "039febf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_function(model, data):\n",
+    "    return np.exp(model.predict(data))\n",
+    "    \n",
+    "fifa_gbm_exp = dx.Explainer(gbm_model, X_test, y_test, \n",
+    "    predict_function = predict_function, label = 'gbm')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43d56f1e",
+   "metadata": {},
+   "source": [
+    "### 21.5.2 Model audit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c6d90d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_md_gbm = fifa_gbm_exp.model_diagnostics()\n",
+    "fifa_md_gbm.plot(variable = \"y\", yvariable = \"y_hat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "918085cc",
+   "metadata": {},
+   "source": [
+    "### 21.6.2 Model understanding (dataset-level explanations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33feb4c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_mp_gbm = fifa_gbm_exp.model_parts()\n",
+    "fifa_mp_gbm.plot(max_vars = 20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef75e566",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_mp_gbm = fifa_gbm_exp.model_profile()\n",
+    "\n",
+    "fifa_mp_gbm.plot(variables = ['movement_reactions',\n",
+    "    'skill_ball_control', 'skill_dribbling', 'age'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb21e031",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_mp_gbm = fifa_gbm_exp.model_profile(type = 'accumulated')\n",
+    "\n",
+    "fifa_mp_gbm.plot(variables = ['movement_reactions',\n",
+    "    'skill_ball_control', 'skill_dribbling', 'age'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b20afbaa",
+   "metadata": {},
+   "source": [
+    "### 21.7.3 Instance-level explanations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ef69b86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cr7 = X.loc['Cristiano Ronaldo',]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3595f8b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_pp_gbm = fifa_gbm_exp.predict_parts(cr7, type='break_down')\n",
+    "fifa_pp_gbm.plot(max_vars = 20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbacd67a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fifa_mp_gbm = fifa_gbm_exp.predict_profile(cr7)\n",
+    "\n",
+    "fifa_mp_gbm.plot(variables =  ['movement_reactions',\n",
+    "    'skill_ball_control', 'skill_dribbling', 'age'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
all code snippets in one jupyter notebook, created to test how the examples from _EMA_ work after changes to the `dalex` package